### PR TITLE
.github/workflows/ci-sage.yml: Add macOS

### DIFF
--- a/.github/workflows/ci-sage.yml
+++ b/.github/workflows/ci-sage.yml
@@ -1,9 +1,9 @@
-name: Run Sage CI for Linux
+name: Run Sage CI for Linux and macOS
 
 ## This GitHub Actions workflow provides:
 ##
 ##  - portability testing, by building and testing this project on many platforms
-##    (Linux variants)
+##    (Linux variants, macOS)
 ##
 ##  - continuous integration, by building and testing other software
 ##    that depends on this project.
@@ -97,4 +97,17 @@ jobs:
       # We prefix the image name with the SPKG name ("scip_sdp_") to avoid the error
       # 'Package "sage-docker-..." is already associated with another repository.'
       docker_push_repository: ghcr.io/${{ github.repository }}/scip_sdp_
+    needs: [dist]
+
+  macos:
+    uses: sagemath/sage/.github/workflows/macos.yml@develop
+    with:
+      osversion_xcodeversion_toxenv_tuples: >-
+        [["latest", "",           "homebrew-macos-usrlocal-minimal"],
+         ["latest", "",           "homebrew-macos-usrlocal-standard"],
+         ["13",     "xcode_15.0", "homebrew-macos-usrlocal-standard"]]
+      targets:           SAGE_CHECK=no SAGE_CHECK_PACKAGES="soplex,scipoptsuite,dsdp,scip_sdp" scip_sdp
+      sage_repo:         sagemath/sage
+      sage_ref:          develop
+      upstream_artifact: upstream
     needs: [dist]

--- a/.github/workflows/ci-sage.yml
+++ b/.github/workflows/ci-sage.yml
@@ -100,14 +100,11 @@ jobs:
     needs: [dist]
 
   macos:
-    uses: sagemath/sage/.github/workflows/macos.yml@develop
+    # Use https://github.com/sagemath/sage/pull/37237
+    uses: mkoeppe/sage/.github/workflows/macos.yml@ci-macos-2024
     with:
-      osversion_xcodeversion_toxenv_tuples: >-
-        [["latest", "",           "homebrew-macos-usrlocal-minimal"],
-         ["latest", "",           "homebrew-macos-usrlocal-standard"],
-         ["13",     "xcode_15.0", "homebrew-macos-usrlocal-standard"]]
       targets:           SAGE_CHECK=no SAGE_CHECK_PACKAGES="soplex,scipoptsuite,dsdp,scip_sdp" scip_sdp
       sage_repo:         sagemath/sage
-      sage_ref:          develop
+      sage_ref:          refs/pull/37237/head
       upstream_artifact: upstream
     needs: [dist]


### PR DESCRIPTION
In particular, tests on the Apple Silicon platform (M1), [runners for which just became available on GitHub Actions](https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/). These are marked as `macos-14` - e.g. https://github.com/scipopt/SCIP-SDP/actions/runs/7796843755/job/21262275734?pr=9